### PR TITLE
Fix: body size limit

### DIFF
--- a/helm/wm-config-values.yaml
+++ b/helm/wm-config-values.yaml
@@ -144,11 +144,6 @@ env:
       configMapKeyRef:
           name: wm-config
           key: MAX_FILE_SIZE_BYTES
-  - name: BODY_SIZE_LIMIT
-    valueFrom:
-    configMapKeyRef:
-        name: wm-config
-        key: BODY_SIZE_LIMIT
   - name: CLAM_DEBUG_MODE
     valueFrom:
       configMapKeyRef:
@@ -289,3 +284,8 @@ env:
       configMapKeyRef:
           name: wm-config
           key: RESTRICT_TO_ORG
+  - name: BODY_SIZE_LIMIT
+    valueFrom:
+      configMapKeyRef:
+        name: wm-config
+        key: BODY_SIZE_LIMIT


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=50aa5ad3fbe6e6504e3aff907befdc09&sysparm_view=&sysparm_time=1752252418317)

This PR fixes a spacing error causing body size limit to be ignored.