### PR TITLE
Feature: Return Siebel status codes by default

### DIFF
--- a/src/common/guards/auth/auth.service.spec.ts
+++ b/src/common/guards/auth/auth.service.spec.ts
@@ -21,6 +21,7 @@ import {
   queryHierarchyEmployeeChildClassName,
 } from '../../../common/constants/parameter-constants';
 import { JwtService } from '@nestjs/jwt';
+import { HttpException } from '@nestjs/common';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -352,7 +353,7 @@ describe('AuthService', () => {
       },
     );
 
-    it('should return false with upstream invalid record for record type', async () => {
+    it('should throw with upstream invalid record for record type', async () => {
       const cacheSpy = jest
         .spyOn(cache, 'get')
         .mockResolvedValueOnce(null)
@@ -374,13 +375,14 @@ describe('AuthService', () => {
             '{ "payLoad": { "entityType": "Case", "entityNumber": "1234567" } }',
         },
       });
-      const isAuthed = await service.getRecordAndValidate(mockRequest, false);
+      await expect(
+        service.getRecordAndValidate(mockRequest, false),
+      ).rejects.toThrow(HttpException);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(4);
-      expect(isAuthed).toBe(false);
     });
 
-    it('should return false with upstream invalid record for employee', async () => {
+    it('should throw with upstream invalid record for employee', async () => {
       const cacheSpy = jest
         .spyOn(cache, 'get')
         .mockResolvedValueOnce(null)
@@ -398,10 +400,11 @@ describe('AuthService', () => {
         }),
         body: {},
       });
-      const isAuthed = await service.getRecordAndValidate(mockRequest, true);
+      await expect(
+        service.getRecordAndValidate(mockRequest, true),
+      ).rejects.toThrow(HttpException);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(3);
-      expect(isAuthed).toBe(false);
     });
   });
 
@@ -536,50 +539,46 @@ describe('AuthService', () => {
       },
     );
 
-    it.each([[404], [500]])(
-      `Should return false on axios error`,
-      async (status) => {
-        const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
-        const spy = jest.spyOn(httpService, 'get').mockImplementation(() => {
-          throw new AxiosError(
-            'Axios Error',
-            status.toString(),
-            {} as InternalAxiosRequestConfig,
-            {},
-            {
-              data: {},
-              status: status,
-              statusText: '',
-              headers: {} as RawAxiosRequestHeaders,
-              config: {} as InternalAxiosRequestConfig,
-            },
-          );
-        });
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [isSuccess, searchspec] =
-          await service.getIsAssignedToOfficeUpstream(
-            validId,
-            RecordType.Case,
-            'idir',
-            officeNames,
-          );
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(cacheSpy).toHaveBeenCalledTimes(1);
-        expect(isSuccess).toBe(false);
-      },
-    );
-
-    it('should return false on token refresh error', async () => {
-      const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(null);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [result, searchspec] = await service.getIsAssignedToOfficeUpstream(
-        validId,
-        validRecordType,
-        'idir',
-        officeNames,
-      );
+    it.each([[404], [500]])(`Should throw on axios error`, async (status) => {
+      const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
+      const spy = jest.spyOn(httpService, 'get').mockImplementation(() => {
+        throw new AxiosError(
+          'Axios Error',
+          status.toString(),
+          {} as InternalAxiosRequestConfig,
+          {},
+          {
+            data: {},
+            status: status,
+            statusText: '',
+            headers: {} as RawAxiosRequestHeaders,
+            config: {} as InternalAxiosRequestConfig,
+          },
+        );
+      });
+      await expect(
+        service.getIsAssignedToOfficeUpstream(
+          validId,
+          RecordType.Case,
+          'idir',
+          officeNames,
+        ),
+      ).rejects.toThrow(HttpException);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(cacheSpy).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(false);
+    });
+
+    it('should throw on token refresh error', async () => {
+      const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(null);
+      await expect(
+        service.getIsAssignedToOfficeUpstream(
+          validId,
+          validRecordType,
+          'idir',
+          officeNames,
+        ),
+      ).rejects.toThrow(HttpException);
+      expect(cacheSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -746,7 +745,7 @@ describe('AuthService', () => {
     );
 
     it.each([[{}], [{ items: [{}] }]])(
-      'should return false when employee status not in response',
+      'should throw when employee status not in response',
       async (data) => {
         const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
         const spy = jest.spyOn(httpService, 'get').mockReturnValueOnce(
@@ -761,46 +760,46 @@ describe('AuthService', () => {
             statusText: 'OK',
           } as AxiosResponse<any, any>),
         );
-        const result = await service.getEmployeeActiveUpstream(testIdir);
+        await expect(
+          service.getEmployeeActiveUpstream(testIdir),
+        ).rejects.toThrow(HttpException);
         expect(spy).toHaveBeenCalledTimes(1);
         expect(cacheSpy).toHaveBeenCalledTimes(1);
-        expect(result).toEqual([false, undefined]);
       },
     );
 
-    it.each([[404], [500]])(
-      `Should return false on axios error`,
-      async (status) => {
-        const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
-        const spy = jest.spyOn(httpService, 'get').mockImplementation(() => {
-          throw new AxiosError(
-            'Axios Error',
-            status.toString(),
-            {} as InternalAxiosRequestConfig,
-            {},
-            {
-              data: {},
-              status: status,
-              statusText: '',
-              headers: {} as RawAxiosRequestHeaders,
-              config: {} as InternalAxiosRequestConfig,
-            },
-          );
-        });
-        const isActive = await service.getEmployeeActiveUpstream(testIdir);
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(cacheSpy).toHaveBeenCalledTimes(1);
-        expect(isActive).toEqual([false, undefined]);
-      },
-    );
+    it.each([[404], [500]])(`Should throw on axios error`, async (status) => {
+      const cacheSpy = jest.spyOn(cache, 'get').mockResolvedValueOnce(' ');
+      const spy = jest.spyOn(httpService, 'get').mockImplementation(() => {
+        throw new AxiosError(
+          'Axios Error',
+          status.toString(),
+          {} as InternalAxiosRequestConfig,
+          {},
+          {
+            data: {},
+            status: status,
+            statusText: '',
+            headers: {} as RawAxiosRequestHeaders,
+            config: {} as InternalAxiosRequestConfig,
+          },
+        );
+      });
+      await expect(service.getEmployeeActiveUpstream(testIdir)).rejects.toThrow(
+        HttpException,
+      );
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(cacheSpy).toHaveBeenCalledTimes(1);
+    });
 
-    it('should return false on token refresh error', async () => {
+    it('should throw on token refresh error', async () => {
       const cacheSpy = jest
         .spyOn(cache, 'get')
         .mockResolvedValueOnce(undefined);
-      const result = await service.getEmployeeActiveUpstream(testIdir);
+      await expect(service.getEmployeeActiveUpstream(testIdir)).rejects.toThrow(
+        HttpException,
+      );
       expect(cacheSpy).toHaveBeenCalledTimes(1);
-      expect(result).toEqual([false, undefined]);
     });
   });
 });

--- a/src/common/guards/auth/auth.service.ts
+++ b/src/common/guards/auth/auth.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { Request } from 'express';
 import {
   EntityRecordMap,
@@ -363,11 +369,35 @@ export class AuthService {
           buildNumber: this.buildNumber,
           function: this.getIsAssignedToOfficeUpstream.name,
         });
+        if (error.status === 404) {
+          throw new HttpException({}, HttpStatus.NO_CONTENT, { cause: error });
+        }
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
     }
-    return [false, searchspec];
   }
 
   async getEmployeeActiveUpstream(
@@ -428,10 +458,31 @@ export class AuthService {
         });
         await this.cacheManager.set(officeNamesKey, undefined, this.cacheTime);
         await this.cacheManager.set(idir, false, this.cacheTime);
+        throw new HttpException(
+          {
+            status: error.status,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          error.status,
+          { cause: error },
+        );
       } else {
         this.logger.error({ error, buildNumber: this.buildNumber });
+        throw new HttpException(
+          {
+            status: HttpStatus.INTERNAL_SERVER_ERROR,
+            error:
+              error.response?.data !== undefined
+                ? error.response?.data
+                : error.message,
+          },
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          { cause: error },
+        );
       }
     }
-    return [false, undefined];
   }
 }


### PR DESCRIPTION
[Story Link](https://bcsocialsector.service-now.com/rm_story.do?sys_id=5fccf7b4fbf6ee504e3aff907befdc35&sysparm_view=&sysparm_time=1752594385696)

This PR changes auth guard to always return siebel status codes (except 404, which changes to 204)